### PR TITLE
Added useMemo to createControls so that controls states persist through rerenders

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useMemo } from "react"
 import {
   OrbitControlsChangeEvent,
   OrbitControlsProps,
@@ -37,7 +37,7 @@ function OrbitControls({ controls, ...props }: OrbitControlsInternalProps) {
 }
 
 export default function useControls() {
-  const controls = createControls()
+  const controls = useMemo(() => createControls(), [])
 
   return [
     (props: OrbitControlsProps) => (


### PR DESCRIPTION
Currently, if you use useControls in any react component and update a separate state in that component, the camera will blow up with any interactions. This is because createControls is re-run every time a state is updated and resetting the height variable. In order to avoid this, a useMemo with an empty dep array is added so that the control states are persisted across renders 