### PR TITLE
fix: stop claiming touch on quick touches

### DIFF
--- a/lib/index.cjs.js
+++ b/lib/index.cjs.js
@@ -18,7 +18,7 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 ***************************************************************************** */
-/* global Reflect, Promise */
+/* global Reflect, Promise, SuppressedError, Symbol */
 
 
 var __assign = function() {
@@ -43,6 +43,11 @@ function __rest(s, e) {
         }
     return t;
 }
+
+typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
 
 var EPSILON = 0.000001;
 var STATE = {
@@ -78,6 +83,7 @@ function createControls() {
     var height = 0;
     var scope = __assign(__assign({}, partialScope), { onChange: function (event) { } });
     var internals = {
+        moveStart: new three.Vector3(),
         rotateStart: new three.Vector2(),
         rotateEnd: new three.Vector2(),
         rotateDelta: new three.Vector2(),
@@ -93,6 +99,22 @@ function createControls() {
         state: STATE.NONE,
     };
     var functions = {
+        shouldClaimTouch: function (event) {
+            // If there's 1 touch it may not be related to orbit-controls,
+            // therefore we delay "claiming" the touch.
+            if (event.nativeEvent.touches.length === 1) {
+                var _a = event.nativeEvent.touches[0], x = _a.locationX, y = _a.locationY, t = _a.timestamp;
+                var dx = Math.abs(internals.moveStart.x - x);
+                var dy = Math.abs(internals.moveStart.y - y);
+                var dt = Math.pow(internals.moveStart.z - t, 2);
+                if (!internals.moveStart.length() || (dx * dt <= 1000 && dy * dt <= 1000)) {
+                    internals.moveStart.set(x, y, t);
+                    return false;
+                }
+                internals.moveStart.set(0, 0, 0);
+            }
+            return true;
+        },
         handleTouchStartRotate: function (event) {
             if (event.nativeEvent.touches.length === 1) {
                 internals.rotateStart.set(event.nativeEvent.touches[0].locationX, event.nativeEvent.touches[0].locationY);
@@ -365,14 +387,14 @@ function createControls() {
             // See https://reactnative.dev/docs/gesture-responder-system
             onStartShouldSetResponder: function (event) {
                 // On some devices this fires only for 2+ touches.
-                if (!scope.enabled)
+                if (!scope.enabled || !functions.shouldClaimTouch(event))
                     return false;
                 functions.onTouchStart(event);
                 return true;
             },
             onMoveShouldSetResponder: function (event) {
                 // And on the same devices this fires only for 1 touch.
-                if (!scope.enabled)
+                if (!scope.enabled || !functions.shouldClaimTouch(event))
                     return false;
                 functions.onTouchStart(event);
                 return true;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,7 @@
-import * as react_native_types from "react-native/types"
+import * as react_native from "react-native"
+import { GestureResponderEvent, LayoutChangeEvent } from "react-native"
 import React from "react"
 import { PerspectiveCamera, OrthographicCamera, Vector3, Matrix4 } from "three"
-import { GestureResponderEvent, LayoutChangeEvent } from "react-native"
 
 declare const partialScope: {
   camera: PerspectiveCamera | OrthographicCamera | undefined
@@ -43,6 +43,7 @@ declare function createControls(): {
   }
   functions: {
     update: () => void
+    shouldClaimTouch(event: GestureResponderEvent): boolean
     handleTouchStartRotate(event: GestureResponderEvent): void
     handleTouchStartDolly(event: GestureResponderEvent): void
     handleTouchStartPan(event: GestureResponderEvent): void
@@ -81,14 +82,12 @@ type OrbitControlsChangeEvent = Parameters<
 declare function useControls(): readonly [
   (props: OrbitControlsProps) => React.JSX.Element,
   {
-    onLayout(event: react_native_types.LayoutChangeEvent): void
+    onLayout(event: react_native.LayoutChangeEvent): void
     onStartShouldSetResponder(
-      event: react_native_types.GestureResponderEvent
+      event: react_native.GestureResponderEvent
     ): boolean
-    onMoveShouldSetResponder(
-      event: react_native_types.GestureResponderEvent
-    ): boolean
-    onResponderMove(event: react_native_types.GestureResponderEvent): void
+    onMoveShouldSetResponder(event: react_native.GestureResponderEvent): boolean
+    onResponderMove(event: react_native.GestureResponderEvent): void
     onResponderRelease(): void
   }
 ]

--- a/lib/index.esm.js
+++ b/lib/index.esm.js
@@ -16,7 +16,7 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 ***************************************************************************** */
-/* global Reflect, Promise */
+/* global Reflect, Promise, SuppressedError, Symbol */
 
 
 var __assign = function() {
@@ -41,6 +41,11 @@ function __rest(s, e) {
         }
     return t;
 }
+
+typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
 
 var EPSILON = 0.000001;
 var STATE = {
@@ -76,6 +81,7 @@ function createControls() {
     var height = 0;
     var scope = __assign(__assign({}, partialScope), { onChange: function (event) { } });
     var internals = {
+        moveStart: new Vector3(),
         rotateStart: new Vector2(),
         rotateEnd: new Vector2(),
         rotateDelta: new Vector2(),
@@ -91,6 +97,22 @@ function createControls() {
         state: STATE.NONE,
     };
     var functions = {
+        shouldClaimTouch: function (event) {
+            // If there's 1 touch it may not be related to orbit-controls,
+            // therefore we delay "claiming" the touch.
+            if (event.nativeEvent.touches.length === 1) {
+                var _a = event.nativeEvent.touches[0], x = _a.locationX, y = _a.locationY, t = _a.timestamp;
+                var dx = Math.abs(internals.moveStart.x - x);
+                var dy = Math.abs(internals.moveStart.y - y);
+                var dt = Math.pow(internals.moveStart.z - t, 2);
+                if (!internals.moveStart.length() || (dx * dt <= 1000 && dy * dt <= 1000)) {
+                    internals.moveStart.set(x, y, t);
+                    return false;
+                }
+                internals.moveStart.set(0, 0, 0);
+            }
+            return true;
+        },
         handleTouchStartRotate: function (event) {
             if (event.nativeEvent.touches.length === 1) {
                 internals.rotateStart.set(event.nativeEvent.touches[0].locationX, event.nativeEvent.touches[0].locationY);
@@ -363,14 +385,14 @@ function createControls() {
             // See https://reactnative.dev/docs/gesture-responder-system
             onStartShouldSetResponder: function (event) {
                 // On some devices this fires only for 2+ touches.
-                if (!scope.enabled)
+                if (!scope.enabled || !functions.shouldClaimTouch(event))
                     return false;
                 functions.onTouchStart(event);
                 return true;
             },
             onMoveShouldSetResponder: function (event) {
                 // And on the same devices this fires only for 1 touch.
-                if (!scope.enabled)
+                if (!scope.enabled || !functions.shouldClaimTouch(event))
                     return false;
                 functions.onTouchStart(event);
                 return true;


### PR DESCRIPTION
This was making some users unable to use touchable objects on the scene on some Android phones.
This fix adds a very small delay in the beginning of the touches to fix this.

Fixes #27 