### PR TITLE
Fix scope target, remove redundant code

### DIFF
--- a/src/OrbitControls.tsx
+++ b/src/OrbitControls.tsx
@@ -23,8 +23,6 @@ const partialScope = {
 
   enabled: true,
 
-  target: new Vector3(),
-
   minZoom: 0,
   maxZoom: Infinity,
 
@@ -59,6 +57,7 @@ export function createControls() {
 
   const scope = {
     ...partialScope,
+    target: new Vector3(),
     onChange: (event: { target: typeof partialScope }) => {},
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import {
   createControls,
 } from "./OrbitControls"
 import { useFrame, useThree } from "@react-three/fiber/native"
-import { Camera, OrthographicCamera, PerspectiveCamera } from "three"
+import { OrthographicCamera, PerspectiveCamera } from "three"
 
 type OrbitControlsInternalProps = OrbitControlsProps & {
   controls: ReturnType<typeof createControls>


### PR DESCRIPTION
I faced with issue of wrong camera initial position on next 3d-scene creating after using `enabledPan` and change positions with panning on first/previous scene creating iteration.

`partialScope` object uses  on creating a new instance of the orbit controls. But `partialScope.target` value not recreates on resting `partialScope` object because it is object(just copy link to Vector3 instance). This can lead to conflicts when using multiple instances at the same time because they will all reference the same `target` object.

maybe fix it #31