### PR TITLE
fix: Keep height value after rerender by using useState

### DIFF
--- a/src/OrbitControls.tsx
+++ b/src/OrbitControls.tsx
@@ -57,8 +57,8 @@ const partialScope = {
   ignoreQuickPress: false,
 }
 
-export function createControls() {
-  let height = 0
+export function useCreateControls() {
+  const [height, setHeight] = useState(0)
 
   const scope = {
     ...partialScope,
@@ -525,7 +525,7 @@ export function createControls() {
     events: {
       // Equivalent to componentDidMount.
       onLayout(event: LayoutChangeEvent) {
-        height = event.nativeEvent.layout.height
+        setHeight(event.nativeEvent.layout.height)
       },
 
       // See https://reactnative.dev/docs/gesture-responder-system
@@ -567,9 +567,13 @@ type Partial<T> = {
 }
 
 export type OrbitControlsProps = Partial<
-  Omit<ReturnType<typeof createControls>["scope"], "camera">
+  Omit<ReturnType<typeof useCreateControls>["scope"], "camera">
 >
 
 export type OrbitControlsChangeEvent = Parameters<
-  ReturnType<typeof createControls>["scope"]["onChange"]
+  ReturnType<typeof useCreateControls>["scope"]["onChange"]
 >[0]
+function useState(arg0: number): [any, any] {
+  throw new Error("Function not implemented.")
+}
+

--- a/src/OrbitControls.tsx
+++ b/src/OrbitControls.tsx
@@ -1,3 +1,6 @@
+import { invalidate } from "@react-three/fiber/native"
+import { useState } from "react"
+import { GestureResponderEvent, LayoutChangeEvent } from "react-native"
 import {
   Matrix4,
   OrthographicCamera,
@@ -7,8 +10,6 @@ import {
   Vector2,
   Vector3,
 } from "three"
-import { GestureResponderEvent, LayoutChangeEvent } from "react-native"
-import { invalidate } from "@react-three/fiber/native"
 
 const EPSILON = 0.000001
 
@@ -63,7 +64,7 @@ export function useCreateControls() {
   const scope = {
     ...partialScope,
     target: new Vector3(),
-    onChange: (event: { target: typeof partialScope }) => {},
+    onChange: (event: { target: typeof partialScope }) => { },
   }
 
   const internals = {
@@ -573,7 +574,5 @@ export type OrbitControlsProps = Partial<
 export type OrbitControlsChangeEvent = Parameters<
   ReturnType<typeof useCreateControls>["scope"]["onChange"]
 >[0]
-function useState(arg0: number): [any, any] {
-  throw new Error("Function not implemented.")
-}
+
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useMemo } from "react"
 import {
   OrbitControlsChangeEvent,
   OrbitControlsProps,
-  createControls,
+  useCreateControls,
 } from "./OrbitControls"
 import { useFrame, useThree } from "@react-three/fiber/native"
 import { OrthographicCamera, PerspectiveCamera } from "three"
 
 type OrbitControlsInternalProps = OrbitControlsProps & {
-  controls: ReturnType<typeof createControls>
+  controls: ReturnType<typeof useCreateControls>
 }
 
 function OrbitControls({ controls, ...props }: OrbitControlsInternalProps) {
@@ -40,7 +40,7 @@ function OrbitControls({ controls, ...props }: OrbitControlsInternalProps) {
 }
 
 export default function useControls() {
-  const controls = useMemo(() => createControls(), [])
+  const controls = useCreateControls()
 
   return [
     (props: OrbitControlsProps) => (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useMemo } from "react"
+import { useFrame, useThree } from "@react-three/fiber/native"
+import React, { useEffect } from "react"
+import { OrthographicCamera, PerspectiveCamera } from "three"
 import {
   OrbitControlsChangeEvent,
   OrbitControlsProps,
   useCreateControls,
 } from "./OrbitControls"
-import { useFrame, useThree } from "@react-three/fiber/native"
-import { OrthographicCamera, PerspectiveCamera } from "three"
 
 type OrbitControlsInternalProps = OrbitControlsProps & {
   controls: ReturnType<typeof useCreateControls>


### PR DESCRIPTION
I noticed that panning and rotating doesn't work after a rerender while dolly still works, for exemple while developing with hot reload. 
After investigation I noticed that our height was set back to 0, therefore this PR aims at keeping the value of our height between rerender when onLayout is not called. This has been achieved by keeping our height value with a useState