### PR TITLE
Feat: Map controls 

### DIFF
--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -154,8 +154,8 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
 
       if (event.nativeEvent.touches.length === 1) {
         const {
-          locationX: x,
-          locationY: y,
+          pageX: x,
+          pageY: y,
           timestamp: t,
         } = event.nativeEvent.touches[0]
 
@@ -180,18 +180,18 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
     handleTouchStartRotate(event: GestureResponderEvent) {
       if (event.nativeEvent.touches.length === 1) {
         internals.rotateStart.set(
-          event.nativeEvent.touches[0].locationX,
-          event.nativeEvent.touches[0].locationY,
+          event.nativeEvent.touches[0].pageX,
+          event.nativeEvent.touches[0].pageY,
         )
       } else if (event.nativeEvent.touches.length === 2) {
         const x =
           0.5 *
-          (event.nativeEvent.touches[0].locationX +
-            event.nativeEvent.touches[1].locationX)
+          (event.nativeEvent.touches[0].pageX +
+            event.nativeEvent.touches[1].pageX)
         const y =
           0.5 *
-          (event.nativeEvent.touches[0].locationY +
-            event.nativeEvent.touches[1].locationY)
+          (event.nativeEvent.touches[0].pageY +
+            event.nativeEvent.touches[1].pageY)
 
         internals.rotateStart.set(x, y)
       }
@@ -201,11 +201,11 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
       // Ensures this isn't undefined.
       if (event.nativeEvent.touches.length === 2) {
         const dx =
-          event.nativeEvent.touches[0].locationX -
-          event.nativeEvent.touches[1].locationX
+          event.nativeEvent.touches[0].pageX -
+          event.nativeEvent.touches[1].pageX
         const dy =
-          event.nativeEvent.touches[0].locationY -
-          event.nativeEvent.touches[1].locationY
+          event.nativeEvent.touches[0].pageY -
+          event.nativeEvent.touches[1].pageY
         const distance = Math.sqrt(dx * dx + dy * dy)
 
         internals.dollyStart = distance
@@ -215,18 +215,18 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
     handleTouchStartPan(event: GestureResponderEvent) {
       if (event.nativeEvent.touches.length === 1) {
         internals.panStart.set(
-          event.nativeEvent.touches[0].locationX,
-          event.nativeEvent.touches[0].locationY,
+          event.nativeEvent.touches[0].pageX,
+          event.nativeEvent.touches[0].pageY,
         )
       } else if (event.nativeEvent.touches.length === 2) {
         const x =
           0.5 *
-          (event.nativeEvent.touches[0].locationX +
-            event.nativeEvent.touches[1].locationX)
+          (event.nativeEvent.touches[0].pageX +
+            event.nativeEvent.touches[1].pageX)
         const y =
           0.5 *
-          (event.nativeEvent.touches[0].locationY +
-            event.nativeEvent.touches[1].locationY)
+          (event.nativeEvent.touches[0].pageY +
+            event.nativeEvent.touches[1].pageY)
 
         internals.panStart.set(x, y)
       }
@@ -292,18 +292,18 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
     handleTouchMoveRotate(event: GestureResponderEvent) {
       if (event.nativeEvent.touches.length === 1) {
         internals.rotateEnd.set(
-          event.nativeEvent.locationX,
-          event.nativeEvent.locationY,
+          event.nativeEvent.pageX,
+          event.nativeEvent.pageY,
         )
       } else if (event.nativeEvent.touches.length === 2) {
         const x =
           0.5 *
-          (event.nativeEvent.touches[0].locationX +
-            event.nativeEvent.touches[1].locationX)
+          (event.nativeEvent.touches[0].pageX +
+            event.nativeEvent.touches[1].pageX)
         const y =
           0.5 *
-          (event.nativeEvent.touches[0].locationY +
-            event.nativeEvent.touches[1].locationY)
+          (event.nativeEvent.touches[0].pageY +
+            event.nativeEvent.touches[1].pageY)
         internals.rotateEnd.set(x, y)
       }
 
@@ -329,11 +329,11 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
       // Ensures this isn't undefined.
       if (event.nativeEvent.touches.length === 2) {
         const dx =
-          event.nativeEvent.touches[0].locationX -
-          event.nativeEvent.touches[1].locationX
+          event.nativeEvent.touches[0].pageX -
+          event.nativeEvent.touches[1].pageX
         const dy =
-          event.nativeEvent.touches[0].locationY -
-          event.nativeEvent.touches[1].locationY
+          event.nativeEvent.touches[0].pageY -
+          event.nativeEvent.touches[1].pageY
         const distance = Math.sqrt(dx * dx + dy * dy)
 
         internals.dollyEnd = distance
@@ -395,19 +395,16 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
 
     handleTouchMovePan(event: GestureResponderEvent) {
       if (event.nativeEvent.touches.length === 1) {
-        internals.panEnd.set(
-          event.nativeEvent.locationX,
-          event.nativeEvent.locationY,
-        )
+        internals.panEnd.set(event.nativeEvent.pageX, event.nativeEvent.pageY)
       } else if (event.nativeEvent.touches.length === 2) {
         const x =
           0.5 *
-          (event.nativeEvent.touches[0].locationX +
-            event.nativeEvent.touches[1].locationX)
+          (event.nativeEvent.touches[0].pageX +
+            event.nativeEvent.touches[1].pageX)
         const y =
           0.5 *
-          (event.nativeEvent.touches[0].locationY +
-            event.nativeEvent.touches[1].locationY)
+          (event.nativeEvent.touches[0].pageY +
+            event.nativeEvent.touches[1].pageY)
         internals.panEnd.set(x, y)
       } else {
         return
@@ -476,16 +473,16 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
       const touch1 = event.nativeEvent.touches[0]
       const touch2 = event.nativeEvent.touches[1]
 
-      const dx = touch2.locationX - touch1.locationX
-      const dy = touch2.locationY - touch1.locationY
+      const dx = touch2.pageX - touch1.pageX
+      const dy = touch2.pageY - touch1.pageY
       const distance = Math.sqrt(dx * dx + dy * dy)
 
       internals.initialDistance = distance
       internals.initialRotation = Math.atan2(dy, dx)
       internals.lastMoveTimestamp = event.nativeEvent.timestamp
 
-      const midX = (touch1.locationX + touch2.locationX) / 2
-      const midY = (touch1.locationY + touch2.locationY) / 2
+      const midX = (touch1.pageX + touch2.pageX) / 2
+      const midY = (touch1.pageY + touch2.pageY) / 2
       internals.rotateStart.set(midX, midY)
     },
 
@@ -495,8 +492,8 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
       const touch1 = event.nativeEvent.touches[0]
       const touch2 = event.nativeEvent.touches[1]
 
-      const dx = touch2.locationX - touch1.locationX
-      const dy = touch2.locationY - touch1.locationY
+      const dx = touch2.pageX - touch1.pageX
+      const dy = touch2.pageY - touch1.pageY
       const distance = Math.sqrt(dx * dx + dy * dy)
 
       const currentAngle = Math.atan2(dy, dx)
@@ -505,8 +502,8 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
         currentAngle,
       )
 
-      const midX = (touch1.locationX + touch2.locationX) / 2
-      const midY = (touch1.locationY + touch2.locationY) / 2
+      const midX = (touch1.pageX + touch2.pageX) / 2
+      const midY = (touch1.pageY + touch2.pageY) / 2
       const deltaY = midY - internals.rotateStart.y
 
       const timeDelta =

--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -462,11 +462,6 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
     },
     // Functions for map controls
 
-    handleTilt(dy: number) {
-      const tiltSpeed = 0.005
-      this.rotateUp(dy * tiltSpeed)
-    },
-
     handleTouchStartRotateOrZoom(event: GestureResponderEvent) {
       if (event.nativeEvent.touches.length !== 2) return
 

--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -1,3 +1,5 @@
+import { invalidate } from "@react-three/fiber/native"
+import { GestureResponderEvent, LayoutChangeEvent } from "react-native"
 import {
   Matrix4,
   OrthographicCamera,
@@ -7,19 +9,15 @@ import {
   Vector2,
   Vector3,
 } from "three"
-import { GestureResponderEvent, LayoutChangeEvent } from "react-native"
-import { invalidate } from "@react-three/fiber/native"
 
 const EPSILON = 0.000001
 const ZOOM_SPEED_THRESHOLD = 0.5
 const ROTATION_THRESHOLD = 0.01
 
-export const CONTROLMODES = {
-  ORBIT: "orbit",
-  MAP: "map",
-} as const
-
-export type ControlMode = (typeof CONTROLMODES)[keyof typeof CONTROLMODES]
+export const enum ControlsMode {
+  ORBIT = "orbit",
+  MAP = "map",
+}
 
 const partialScope = {
   camera: undefined as PerspectiveCamera | OrthographicCamera | undefined,
@@ -66,27 +64,27 @@ function getShortestAngle(from: number, to: number): number {
   return diff < -Math.PI ? diff + 2 * Math.PI : diff
 }
 
-export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
+export function createControls(mode = ControlsMode.ORBIT) {
   let height = 0
 
   const STATE =
-    mode === CONTROLMODES.MAP
+    mode === ControlsMode.MAP
       ? {
-          NONE: 0,
-          PAN: 1,
-          ROTATE_OR_ZOOM: 2,
-        }
+        NONE: 0,
+        PAN: 1,
+        ROTATE_OR_ZOOM: 2,
+      }
       : {
-          NONE: 0,
-          ROTATE: 1,
-          DOLLY: 2,
-        }
+        NONE: 0,
+        ROTATE: 1,
+        DOLLY: 2,
+      }
 
   const scope = {
     ...partialScope,
     mode,
     target: new Vector3(),
-    onChange: (event: { target: typeof partialScope }) => {},
+    onChange: (event: { target: typeof partialScope }) => { },
   }
 
   const internals = {
@@ -241,13 +239,13 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
     onTouchStart(event: GestureResponderEvent) {
       if (!scope.enabled) return
 
-      if (scope.mode === CONTROLMODES.MAP) {
+      if (scope.mode === ControlsMode.MAP) {
         switch (event.nativeEvent.touches.length) {
           case 1:
-            if (scope.enablePan) {
-              this.handleTouchStartPan(event)
-              internals.state = STATE.PAN!
-            }
+            if (!scope.enablePan) return
+            this.handleTouchStartPan(event)
+            internals.state = STATE.PAN!
+
             break
 
           case 2:
@@ -262,10 +260,10 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
       } else {
         switch (event.nativeEvent.touches.length) {
           case 1:
-            if (scope.enableRotate) {
-              this.handleTouchStartRotate(event)
-              internals.state = STATE.ROTATE!
-            }
+            if (!scope.enableRotate) return
+            this.handleTouchStartRotate(event)
+            internals.state = STATE.ROTATE!
+
             break
 
           case 2:
@@ -428,32 +426,34 @@ export function createControls(mode: ControlMode = CONTROLMODES.ORBIT) {
 
       switch (internals.state) {
         case STATE.ROTATE:
-          if (scope.mode === CONTROLMODES.ORBIT && scope.enableRotate) {
-            this.handleTouchMoveRotate(event)
-            update()
-          }
+          if (scope.mode === ControlsMode.ORBIT) return
+          if (!scope.enableRotate) return
+          this.handleTouchMoveRotate(event)
+          update()
+
           break
 
         case STATE.DOLLY:
-          if (scope.mode === CONTROLMODES.ORBIT) {
-            if (scope.enableZoom) this.handleTouchMoveDolly(event)
-            if (scope.enablePan) this.handleTouchMovePan(event)
-            update()
-          }
+          if (scope.mode !== ControlsMode.ORBIT) return
+          if (!scope.enableZoom && !scope.enablePan) return
+          this.handleTouchMoveDollyPan(event)
+          update()
+
           break
 
         case STATE.PAN:
-          if (scope.mode === CONTROLMODES.MAP && scope.enablePan) {
-            this.handleTouchMovePan(event)
-            update()
-          }
+          if (scope.mode !== ControlsMode.MAP) return
+          if (!scope.enablePan) return
+          this.handleTouchMovePan(event)
+          update()
+
           break
 
         case STATE.ROTATE_OR_ZOOM:
-          if (scope.mode === CONTROLMODES.MAP) {
-            this.handleTouchMoveRotateOrZoom(event)
-            update()
-          }
+          if (scope.mode !== ControlsMode.MAP) return
+          this.handleTouchMoveRotateOrZoom(event)
+          update()
+
           break
 
         default:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,19 @@
 import React, { useEffect, useMemo } from "react"
 import {
-  OrbitControlsChangeEvent,
-  OrbitControlsProps,
+  ControlsChangeEvent,
+  ControlsProps,
   createControls,
-} from "./OrbitControls"
+  CONTROLMODES,
+  ControlMode,
+} from "./Controls"
 import { useFrame, useThree } from "@react-three/fiber/native"
 import { OrthographicCamera, PerspectiveCamera } from "three"
 
-type OrbitControlsInternalProps = OrbitControlsProps & {
+type ControlsInternalProps = ControlsProps & {
   controls: ReturnType<typeof createControls>
 }
 
-function OrbitControls({ controls, ...props }: OrbitControlsInternalProps) {
+function Controls({ controls, ...props }: ControlsInternalProps) {
   const camera = useThree((state) => state.camera)
 
   useEffect(() => {
@@ -22,32 +24,29 @@ function OrbitControls({ controls, ...props }: OrbitControlsInternalProps) {
       controls.scope.camera = camera as PerspectiveCamera | OrthographicCamera
     } else {
       throw new Error(
-        "The camera must be a PerspectiveCamera or OrthographicCamera to orbit controls work"
+        "The camera must be a PerspectiveCamera or OrthographicCamera for controls to work",
       )
     }
-  }, [camera])
+  }, [camera, controls.scope])
 
   useEffect(() => {
     for (const prop in props) {
       ;(controls.scope[prop as keyof typeof controls.scope] as any) =
         props[prop as keyof typeof props]
     }
-  }, [props])
+  }, [props, controls.scope])
 
   useFrame(controls.functions.update, -1)
 
-  return null as unknown as JSX.Element
+  return null
 }
 
-export default function useControls() {
-  const controls = useMemo(() => createControls(), [])
-
+export default function useControls(mode: ControlMode = "orbit") {
+  const controls = useMemo(() => createControls(mode), [mode])
   return [
-    (props: OrbitControlsProps) => (
-      <OrbitControls controls={controls} {...props} />
-    ),
+    (props: ControlsProps) => <Controls controls={controls} {...props} />,
     controls.events,
   ] as const
 }
 
-export { OrbitControlsChangeEvent, OrbitControlsProps }
+export { ControlsChangeEvent, ControlsProps, ControlMode, CONTROLMODES }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,12 @@
+import { useFrame, useThree } from "@react-three/fiber/native"
 import React, { useEffect, useMemo } from "react"
+import { OrthographicCamera, PerspectiveCamera } from "three"
 import {
   ControlsChangeEvent,
+  ControlsMode,
   ControlsProps,
   createControls,
-  CONTROLMODES,
-  ControlMode,
 } from "./Controls"
-import { useFrame, useThree } from "@react-three/fiber/native"
-import { OrthographicCamera, PerspectiveCamera } from "three"
 
 type ControlsInternalProps = ControlsProps & {
   controls: ReturnType<typeof createControls>
@@ -41,7 +40,7 @@ function Controls({ controls, ...props }: ControlsInternalProps) {
   return null
 }
 
-export default function useControls(mode: ControlMode = "orbit") {
+export default function useControls(mode = ControlsMode.ORBIT) {
   const controls = useMemo(() => createControls(mode), [mode])
   return [
     (props: ControlsProps) => <Controls controls={controls} {...props} />,
@@ -49,4 +48,4 @@ export default function useControls(mode: ControlMode = "orbit") {
   ] as const
 }
 
-export { ControlsChangeEvent, ControlsProps, ControlMode, CONTROLMODES }
+export { ControlsChangeEvent, ControlsMode, ControlsProps }


### PR DESCRIPTION
Hey @TiagoCavalcante 

This pull request will add support for map controls without having any breaking changes. It will also fix issues faced by #31 and #40  

#31 - The main problem here was that in react native locationX and locationY values get reset when you enter a new view this would cause abrupt reset of target. Using PageX and PageY will fix this issue 
This can additionally be improved by having a function that checks if touches are outside the canvas and use that to prevent any actions if touches go outside canvas

#40 - I have added the support for Map controls, the changes closely reflect the gesture system used by google maps that native users are more familiar of compared to the existing implementation of map controls in threejs 

One finger touch to Pan 
Two finger rotation to Rotate
Two finger vertical movement for tilt 
Two finger pinch for zoom 

# Description of commits 

- Adds Map control 
- Uses absolute values over relative values (Page over location) as location values reset on entering a different view.

WRT, to API there are no breaking changes so a new release version should be able to support orbit controls and map controls out of the box, However I have internally changed the structure of code to support both the modes effectively 
We can together re do this if you prefer it in a different way.
Please let me know if you need any additional changes to get this merged.


I personally believe that the correct way to using these controls would be to implement `React native gesture handler ` for handling the gestures but untill then this could be the first working version of map controls for react native.